### PR TITLE
Update eslint-plugin-react to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "eslint": "^3.2.2",
+    "eslint": "^2.5.0",
     "eslint-plugin-react": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     }
   },
   "dependencies": {
-    "eslint": "^2.5.0",
     "eslint-plugin-react": "^5.0.1"
+    "eslint": "^3.2.2",
   },
   "devDependencies": {
     "ghooks": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     }
   },
   "dependencies": {
-    "eslint-plugin-react": "^5.0.1"
     "eslint": "^3.2.2",
+    "eslint-plugin-react": "^6.0.0"
   },
   "devDependencies": {
     "ghooks": "^1.0.3",

--- a/react.js
+++ b/react.js
@@ -94,8 +94,7 @@ module.exports = {
     'react/no-danger': 2,
     // Prevent usage of setState in componentDidMount
     'react/no-did-mount-set-state': [
-      2,
-      'allow-in-func',
+      2
     ],
     // Prevent usage of setState in componentDidUpdate
     'react/no-did-update-set-state': [

--- a/react.js
+++ b/react.js
@@ -128,6 +128,6 @@ module.exports = {
     // Enforce component methods order
     'react/sort-comp': 2,
     // Prevent missing parentheses around multiline JSX
-    'react/wrap-multilines': 2,
+    'react/jsx-wrap-multilines': 2,
   },
 };

--- a/react.js
+++ b/react.js
@@ -95,12 +95,10 @@ module.exports = {
     // Prevent usage of setState in componentDidMount
     'react/no-did-mount-set-state': [
       2,
-      'allow-in-func',
     ],
     // Prevent usage of setState in componentDidUpdate
     'react/no-did-update-set-state': [
       2,
-      'allow-in-func',
     ],
     // Prevent direct mutation of this.state
     'react/no-direct-mutation-state': 2,


### PR DESCRIPTION
allow-in-func is now default behavior for react/no-did-mount-set-state:
(https://github.com/yannickcr/eslint-plugin-react/commit/376dc53656f78059fb405d9e30c2f402717f6882)
